### PR TITLE
default everything to ai-01.contentfabric.io (remove ai-03/atlanta references)

### DIFF
--- a/src/components/search-bar/SearchBar.jsx
+++ b/src/components/search-bar/SearchBar.jsx
@@ -13,7 +13,7 @@ import {
   TextInput
 } from "@mantine/core";
 import {useEffect, useState} from "react";
-import {searchStore, tenantStore} from "@/stores/index.js";
+import {searchStore, tenantStore, summaryStore, highlightsStore} from "@/stores/index.js";
 import {CameraIcon, DownArrowIcon, GearIcon, MusicIcon, SubmitIcon} from "@/assets/icons";
 import {observer} from "mobx-react-lite";
 import styles from "@/components/search-bar/SearchBar.module.css";
@@ -130,19 +130,21 @@ const AdvancedSection = observer(({
       <Text c="elv-gray.8" size="xl" fw={700} mb={8}>Version</Text>
       <Radio.Group
         value={searchStore.searchHostname}
-        defaultValue="ai"
+        defaultValue="ai.contentfabric.io"
         onChange={(value) => {
           searchStore.SetSearchHostname({host: value});
+          summaryStore.SetMlcacheHostname({host: value});
+          highlightsStore.SetMlcacheHostname({host: value});
         }}
       >
         <Radio
           label="AI 1"
-          value="ai"
+          value="ai.contentfabric.io"
           mb={16}
         />
         <Radio
           label="AI 2"
-          value="ai-02"
+          value="ai-02.contentfabric.io"
           mb={16}
         />
       </Radio.Group>

--- a/src/components/video/Video.jsx
+++ b/src/components/video/Video.jsx
@@ -49,7 +49,7 @@ const Video = observer(({
           {
             clientOptions: {
               client: rootStore.client,
-              network: EluvioPlayerParameters.networks[rootStore.networkInfo.name === "main" ? "MAIN" : "DEMO"],
+              network: EluvioPlayerParameters.networks[rootStore.networkName === "main" ? "MAIN" : "DEMO"],
               ...clientOptions
             },
             sourceOptions: {

--- a/src/stores/HighlightsStore.js
+++ b/src/stores/HighlightsStore.js
@@ -3,6 +3,8 @@ import {searchStore} from "@/stores/index.js";
 
 // Store for managing clip generated highlights
 class HighlightsStore {
+  mlcacheHostname = "ai.contentfabric.io"
+
   constructor(rootStore) {
     makeAutoObservable(this);
 
@@ -11,6 +13,10 @@ class HighlightsStore {
 
   get client() {
     return this.rootStore.client;
+  }
+
+  SetMlcacheHostname = ({host="ai.contentfabric.io"}) => {
+    this.mlcacheHostname = host
   }
 
   GetHighlightsUrl = flow(function * ({objectId, startTime, endTime, cache=true}) {
@@ -34,7 +40,7 @@ class HighlightsStore {
       });
 
       const _pos = url.indexOf("/rep/");
-      const newUrl = `https://ai-03.contentfabric.io/mlcache/highlight/q/${objectId}`
+      const newUrl = `https://${this.mlcacheHostname}/mlcache/highlight/q/${objectId}`
         .concat(url.slice(_pos));
 
       return newUrl;

--- a/src/stores/SearchStore.js
+++ b/src/stores/SearchStore.js
@@ -13,7 +13,7 @@ class SearchStore {
   };
 
   customIndex = "";
-  searchHostname = "ai";
+  searchHostname = "ai.contentfabric.io";
   searchSummaryType = "synopsis"; // synopsis, caption, caption2
   searchContentType; // ALL, IMAGES, VIDEOS
   resultsViewType; // Show all results vs results that have a high score.
@@ -177,7 +177,7 @@ class SearchStore {
     this.currentSearch.index = index;
   };
 
-  SetSearchHostname = ({host="ai"}) => {
+  SetSearchHostname = ({host="ai.contentfabric.io"}) => {
     this.searchHostname = host;
   };
 
@@ -465,7 +465,7 @@ class SearchStore {
         `qlibs/${libraryId}/q/${objectId}`;
 
       const _pos = url.indexOf("/rep/");
-      const newUrl = `https://${this.searchHostname}.contentfabric.io/search/${contentObject}`.concat(url.slice(_pos));
+      const newUrl = `https://${this.searchHostname}/search/${contentObject}`.concat(url.slice(_pos));
       return { url: newUrl, status: 0 };
     } catch(error) {
       // eslint-disable-next-line no-console

--- a/src/stores/SummaryStore.js
+++ b/src/stores/SummaryStore.js
@@ -4,6 +4,7 @@ import {searchStore} from "@/stores/index.js";
 // Store for managing clip generated summaries and captions
 class SummaryStore {
   loadingSummary = false;
+  mlcacheHostname = "ai.contentfabric.io"
 
   constructor(rootStore) {
     makeAutoObservable(this);
@@ -13,6 +14,10 @@ class SummaryStore {
 
   get client() {
     return this.rootStore.client;
+  }
+
+  SetMlcacheHostname = ({host="ai.contentfabric.io"}) => {
+     this.mlcacheHostname = host
   }
 
   ToggleLoading = () => {
@@ -38,7 +43,7 @@ class SummaryStore {
       });
 
       const _pos = url.indexOf("/rep/");
-      const newUrl = `https://ai-02.contentfabric.io/caption/q/${objectId}`
+      const newUrl = `https://${this.mlcacheHostname}/caption/q/${objectId}`
         .concat(url.slice(_pos));
 
       return newUrl;
@@ -108,7 +113,7 @@ class SummaryStore {
       });
 
       const _pos = url.indexOf("/rep/");
-      const newUrl = `https://${server}.contentfabric.io/${requestUrl}/q/${objectId}`
+      const newUrl = `https://${this.mlcacheHostname}/${requestUrl}/q/${objectId}`
         .concat(url.slice(_pos));
 
       return newUrl;

--- a/src/stores/TagStore.js
+++ b/src/stores/TagStore.js
@@ -51,7 +51,7 @@ class TagStore {
     });
 
     const _pos = url.indexOf(`/${requestRep}?`);
-    const newUrl = `https://${this.rootStore.searchStore.searchHostname}.contentfabric.io/search/qlibs/${libraryId}/q/${objectId}`
+    const newUrl = `https://${this.rootStore.searchStore.searchHostname}/search/qlibs/${libraryId}/q/${objectId}`
       .concat(url.slice(_pos));
 
     try {


### PR DESCRIPTION
This PR was going to need to happen anyway but got pushed up a bit due to annoyance from our ATL machine provider.

This sends everything through the same host, as this is the way we are going to standardize ML deployments.

Right now only AI1 is fully working, AI2 is partially working and I will get that up later.

NOTE that once this is deployed we can no longer use ai-03 services as they are removed from the code.

Suggestion is to have Zenia sanity check this (see my one self comment) since it was done semi-hastily but I did test it locally.

Then we can deploy to prod dev, and hold off on prod deployment until we are tested and/or our box gets shut off.

If we do end up keeping ai-03 then there will need to be some additional adjustments of some form.
